### PR TITLE
apple-app-site-association: add webcredentials

### DIFF
--- a/apple-app-site-association
+++ b/apple-app-site-association
@@ -7,5 +7,8 @@
                 "paths": [ "/app/*", "/beta/*", "/develop/*", "/staging/*", "/_matrix/identity/api/v1/validate/email/*" ]
             }
         ]
+    },
+    "webcredentials": {
+        "apps": [ "7J4U792NQT.im.vector.app" ]
     }
 }


### PR DESCRIPTION
to store Riot credentials used in the app and in Safari (and share between them)

Required for https://github.com/vector-im/riot-ios/issues/2066.

https://developer.apple.com/documentation/security/password_autofill/setting_up_an_app_s_associated_domains?language=objc