### PR TITLE
Replace Google links with direct ones in privacy policy

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -215,7 +215,7 @@ for up to a year after application unless you request that we remove before the 
 &ldquo;Your Rights&rdquo;)</p>
 			<h2>Your rights</h2>
 			<p>Under the <a
-href="https://www.google.com/url?q=http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri%3DCELEX:32016R0679%26from%3DEN&amp;sa=D&amp;ust=1527075901359000">General
+href="https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32016R0679&from=EN">General
 Data Protection Regulation</a><p>&nbsp;you have a number of
 important rights free of charge. In summary, those include rights
 to:</p>
@@ -248,7 +248,7 @@ of any data protection laws.</li>
 			<p>For further information on
 each of those rights, including the circumstances in which they apply, see the
 <a
-href="https://www.google.com/url?q=http://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/&amp;sa=D&amp;ust=1527075901360000">Guidance
+href="https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/">Guidance
 from the UK Information Commissioner&rsquo;s Office (ICO) on individuals rights
 under the General Data Protection Regulation.</a></p>
 <p>If you would like to
@@ -267,14 +267,14 @@ relates.</li>
 that we &nbsp;can resolve any query or concern you raise about Our use of your
 information.</p>
 			<p>The <a
-href="https://www.google.com/url?q=http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri%3DCELEX:32016R0679%26from%3DEN&amp;sa=D&amp;ust=1527075901361000">General
+href="https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32016R0679&from=EN">General
 Data Protection Regulation</a>&nbsp;also gives you right
 to lodge a complaint with a supervisory authority, in particular in the European
 Union (or European Economic Area) state where you work, normally live or where
 any alleged infringement of data protection laws occurred. The supervisory
 authority in the UK is the Information Commissioner who may be contacted at
 <a
-href="https://www.google.com/url?q=https://ico.org.uk/concerns/&amp;sa=D&amp;ust=1527075901362000">https://ico.org.uk/concerns/</a></p>
+href="https://ico.org.uk/concerns/">https://ico.org.uk/concerns/</a></p>
 <h2>Contact</h2>
 <p>All questions, comments and requests regarding this Privacy Notice
 should be addressed to <a href="mailto:support@vector.im" target="_top">support@vector.im</a></p>


### PR DESCRIPTION
All links in the privacy policy are Google links themselves directing to the related resources. This PR replaces them with direct ones.